### PR TITLE
Configure Render deployment

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,13 @@
+# Build stage: compile the application and package as a runnable jar
+FROM maven:3.9.4-eclipse-temurin-17 AS build
+WORKDIR /app
+COPY pom.xml .
+COPY src ./src
+RUN mvn -B clean package -DskipTests
+
+# Runtime stage: run the jar with a lightweight JRE
+FROM eclipse-temurin:17-jre-jammy
+WORKDIR /app
+COPY --from=build /app/target/backend-0.0.1-SNAPSHOT.jar app.jar
+EXPOSE 8080
+CMD ["java", "-jar", "app.jar"]

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,7 +1,7 @@
 # MySQL database configuration
-spring.datasource.url=jdbc:mysql://localhost:3306/testimx_db?useSSL=false&serverTimezone=UTC&allowPublicKeyRetrieval=true
-spring.datasource.username=root
-spring.datasource.password=secret
+spring.datasource.url=${DATABASE_URL:jdbc:mysql://localhost:3306/testimx_db?useSSL=false&serverTimezone=UTC&allowPublicKeyRetrieval=true}
+spring.datasource.username=${DATABASE_USERNAME:root}
+spring.datasource.password=${DATABASE_PASSWORD:secret}
 
 # JPA & Hibernate settings
 spring.jpa.hibernate.ddl-auto=update
@@ -10,12 +10,12 @@ spring.jpa.show-sql=false
 spring.jpa.properties.hibernate.format_sql=true
 
 # Server configuration
-server.port=8080
+server.port=${PORT:8080}
 
 # JWT configuration
 # The secret should be replaced with a strong randomly generated value in production.
-qaquiz.app.jwtSecret=ChangeThisSecretForProduction
-qaquiz.app.jwtExpirationMs=86400000  # 24 hours
+qaquiz.app.jwtSecret=${JWT_SECRET:ChangeThisSecretForProduction}
+qaquiz.app.jwtExpirationMs=${JWT_EXPIRATION:86400000}  # 24 hours
 
 # Logging pattern
 logging.level.org.springframework=INFO

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,32 @@
+services:
+  - type: web
+    name: qaquiz-backend
+    env: docker
+    rootDir: backend
+    dockerfilePath: Dockerfile
+    plan: free
+    envVars:
+      - key: DATABASE_URL
+        fromDatabase:
+          name: qaquiz-db
+          property: connectionString
+      - key: DATABASE_USERNAME
+        fromDatabase:
+          name: qaquiz-db
+          property: user
+      - key: DATABASE_PASSWORD
+        fromDatabase:
+          name: qaquiz-db
+          property: password
+      - key: JWT_SECRET
+        generateValue: true
+
+staticSites:
+  - name: qaquiz-frontend
+    rootDir: frontend
+    staticPublishPath: .
+
+databases:
+  - name: qaquiz-db
+    plan: free
+    databaseName: testimx_db


### PR DESCRIPTION
## Summary
- Parameterize backend properties for Render with env-driven DB and port settings.
- Add Dockerfile to build and run Spring Boot service on Render.
- Introduce render.yaml configuring web service, static site, and MySQL database.

## Testing
- ⚠️ `mvn -q clean package` *(failed: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c705080c6483238f16a823650fc496