### PR TITLE
Fix JWT expiration property parsing

### DIFF
--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -15,7 +15,8 @@ server.port=${PORT:8080}
 # JWT configuration
 # The secret should be replaced with a strong randomly generated value in production.
 qaquiz.app.jwtSecret=${JWT_SECRET:ChangeThisSecretForProduction}
-qaquiz.app.jwtExpirationMs=${JWT_EXPIRATION:86400000}  # 24 hours
+# JWT expiration in milliseconds (default: 24 hours)
+qaquiz.app.jwtExpirationMs=${JWT_EXPIRATION:86400000}
 
 # Logging pattern
 logging.level.org.springframework=INFO


### PR DESCRIPTION
## Summary
- move JWT expiration comment to its own line so Spring can parse integer value

## Testing
- `mvn -q test` *(fails: Could not resolve spring-boot-starter-parent due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c7129fcb608323b3cbb95def8a00cd