### PR TITLE
Default to H2 in-memory database

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -63,6 +63,12 @@
             <groupId>com.mysql</groupId>
             <artifactId>mysql-connector-j</artifactId>
         </dependency>
+        <!-- H2 in-memory database for local development and tests -->
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>runtime</scope>
+        </dependency>
         <!-- Lombok reduces boilerplate -->
         <dependency>
             <groupId>org.projectlombok</groupId>

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,11 +1,14 @@
-# MySQL database configuration
-spring.datasource.url=${DATABASE_URL:jdbc:mysql://localhost:3306/testimx_db?useSSL=false&serverTimezone=UTC&allowPublicKeyRetrieval=true}
-spring.datasource.username=${DATABASE_USERNAME:root}
-spring.datasource.password=${DATABASE_PASSWORD:secret}
+# Database configuration defaults to an in-memory H2 instance for easier
+# development and testing. The values can be overridden via environment
+# variables to point to a persistent database such as MySQL in production.
+spring.datasource.url=${DATABASE_URL:jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;MODE=MYSQL}
+spring.datasource.username=${DATABASE_USERNAME:sa}
+spring.datasource.password=${DATABASE_PASSWORD:}
+spring.datasource.driver-class-name=${DATABASE_DRIVER:org.h2.Driver}
 
 # JPA & Hibernate settings
 spring.jpa.hibernate.ddl-auto=update
-spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL8Dialect
+spring.jpa.properties.hibernate.dialect=${HIBERNATE_DIALECT:org.hibernate.dialect.H2Dialect}
 spring.jpa.show-sql=false
 spring.jpa.properties.hibernate.format_sql=true
 


### PR DESCRIPTION
## Summary
- Use an in-memory H2 database by default for the backend
- Allow overriding database and dialect settings via environment variables

## Testing
- `cd backend && mvn -q test && cd ..` *(fails: Non-resolvable parent POM org.springframework.boot:spring-boot-starter-parent:3.2.3 because network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c7182ed11c8323adb9b5e266efd9e3